### PR TITLE
Fix: Import ConfigFlow handler in __init__.py

### DIFF
--- a/custom_components/braiins_pool/__init__.py
+++ b/custom_components/braiins_pool/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .coordinator import BraiinsDataUpdateCoordinator
 from .api import BraiinsPoolApiClient
 from .const import DOMAIN, CONF_API_KEY
+from .config_flow import BraiinsPoolConfigFlow
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(minutes=15)  # Define an update interval


### PR DESCRIPTION
Resolves an "Invalid handler specified" error during config flow by ensuring that the BraiinsPoolConfigFlow class is imported into the `__init__.py` of the integration. This makes the handler discoverable by Home Assistant during the setup process.